### PR TITLE
corrected typo in if check for buster.

### DIFF
--- a/install.sh.in
+++ b/install.sh.in
@@ -167,7 +167,7 @@ if [ -f /etc/debian_version ]; then
 	elif [ "$dvers" = "9" -o "$dvers" = "stretch" ]; then
 		echo '*** Found Debian "stretch" (or similar), creating /etc/apt/sources.list.d/zerotier.list'
 		echo "deb ${ZT_BASE_URL_HTTP}debian/stretch stretch main" >/tmp/zt-sources-list
-	elif [ "$dvers" = "10" -o "$dvers" = "11" -o "$dvers" = "sid" -o "$dvers" = "buster"]; then
+	elif [ "$dvers" = "10" -o "$dvers" = "11" -o "$dvers" = "sid" -o "$dvers" = "buster" ]; then
 		echo '*** Found Debian "buster", or "sid" (or similar), creating /etc/apt/sources.list.d/zerotier.list'
 		echo "deb ${ZT_BASE_URL_HTTP}debian/buster stretch main" >/tmp/zt-sources-list
 	else


### PR DESCRIPTION
Syntax error when running on Linux Mint 18:

root@mine:~# curl -s https://install.zerotier.com/  > zt.sh
root@mine:~# sh zt.sh 

*** ZeroTier One Quick Install for Unix-like Systems

*** Tested distributions and architectures:
***   MacOS (10.7+) on x86_64 (just installs ZeroTier One.pkg)
***   Debian (7+) on x86_64, x86, arm, and arm64
***   RedHat/CentOS (6+) on x86_64 and x86
***   Fedora (16+) on x86_64 and x86
***   SuSE (12+) on x86_64 and x86
***   Mint (18+) on x86_64, x86, arm, and arm64

*** Please report problems to contact@zerotier.com and we will try to fix.

*** Detecting Linux Distribution

zt.sh: 175: [: missing ]
*** FAILED: unrecognized or ancient distribution: buster
root@mine:~# 
