### PR TITLE
place unarmored gpg key in /etc/apt/trusted.gpg.d/ on modern debian based distributions

### DIFF
--- a/install.sh.in
+++ b/install.sh.in
@@ -228,7 +228,12 @@ if [ -f /etc/debian_version ]; then
 	$SUDO mv -f /tmp/zt-sources-list /etc/apt/sources.list.d/zerotier.list
 	$SUDO chown 0 /etc/apt/sources.list.d/zerotier.list
 	$SUDO chgrp 0 /etc/apt/sources.list.d/zerotier.list
-	$SUDO apt-key add /tmp/zt-gpg-key
+
+	if [ -d /etc/apt/trusted.gpg.d ]; then 
+		cat /tmp/zt-gpg-key | gpg --dearmor | $SUDO tee /etc/apt/trusted.gpg.d/zerotier.com.gpg > /dev/null
+	else
+		$SUDO apt-key add /tmp/zt-gpg-key
+	fi
 
 	echo
 	echo '*** Installing zerotier-one package...'


### PR DESCRIPTION
Gets rid of warnings when using apt using the old `apt-key` method:

```
W: http://download.zerotier.com/debian/jammy/dists/jammy/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
```