### PR TITLE
Update to recognise AlmaLinux and handle as CentOS or Rocky

### DIFF
--- a/install.sh.in
+++ b/install.sh.in
@@ -260,7 +260,7 @@ elif [ -d /etc/yum.repos.d ]; then
 		else
 			baseurl="${ZT_BASE_URL_HTTP}redhat/fc/22"
 		fi
-	elif [ -n "`cat /etc/redhat-release 2>/dev/null | grep -i centos`" -o -n "`cat /etc/redhat-release 2>/dev/null | grep -i enterprise`" -o -n "`cat /etc/redhat-release 2>/dev/null | grep -i rocky`" ]; then
+	elif [ -n "`cat /etc/redhat-release 2>/dev/null | grep -i centos`" -o -n "`cat /etc/redhat-release 2>/dev/null | grep -i enterprise`" -o -n "`cat /etc/redhat-release 2>/dev/null | grep -i rocky`" -o -n "`cat /etc/redhat-release 2>/dev/null | grep -i alma`" ]; then
 		echo "*** Found RHEL/CentOS/Rocky, creating /etc/yum.repos.d/zerotier.repo"
 		baseurl="${ZT_BASE_URL_HTTP}redhat/el/\$releasever"
 	elif [ -n "`cat /etc/system-release 2>/dev/null | grep -i amazon`" ]; then


### PR DESCRIPTION
Without this, running the install script on an AlmaLinux host results in the following suboptimal outcome:

*** Detecting Linux Distribution

*** Found unknown yum-based repo, using el/7, creating /etc/yum.repos.d/zerotier.repo

*** Installing ZeroTier service package...
ZeroTier, Inc. RPM Release Repository                                                                                                                                                                                                                                                                                                                             40 kB/s |  19 kB     00:00
Error:
 Problem: cannot install the best candidate for the job
  - nothing provides libcrypto.so.10()(64bit) needed by zerotier-one-1.10.1-1.el7.x86_64
  - nothing provides libcrypto.so.10(OPENSSL_1.0.1_EC)(64bit) needed by zerotier-one-1.10.1-1.el7.x86_64
  - nothing provides libcrypto.so.10(OPENSSL_1.0.2)(64bit) needed by zerotier-one-1.10.1-1.el7.x86_64
  - nothing provides libcrypto.so.10(libcrypto.so.10)(64bit) needed by zerotier-one-1.10.1-1.el7.x86_64
  - nothing provides libssl.so.10()(64bit) needed by zerotier-one-1.10.1-1.el7.x86_64
  - nothing provides libssl.so.10(libssl.so.10)(64bit) needed by zerotier-one-1.10.1-1.el7.x86_64
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)

*** Package installation failed! Unfortunately there may not be a package
*** for your architecture or distribution. For the source go to:
*** https://github.com/zerotier/ZeroTierOne
