### PR TITLE
Create some tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: Curl | Bash Test
+on:
+  push:
+    paths:
+      - install.sh.in
+      - .github/workflows/ci.yml
+    # branches: [ main ]
+  schedule:
+    - cron: "0 0 * * 0"   # weekly
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: sudo apt install -y shellcheck
+      - run: shellcheck -S error install.sh.in
+
+  curl-bash:
+    needs: shellcheck
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container:
+          - "ubuntu:latest"
+          - "ubuntu:24.10"
+          - "ubuntu:24.04"
+          - "ubuntu:22.04"
+          - "ubuntu:20.04"
+          - "debian:latest"
+          - "debian:12"
+          - "debian:11"
+          - "debian:10"
+          - "kalilinux/kali-rolling:latest"
+
+    container:
+      image: ${{ matrix.container }}
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: apt
+        run: apt-get -y update && apt-get -y install curl gnupg2 gnupg gpg || true
+      - name: install ${{ matrix.container }}
+        run: bash install.sh.in

--- a/install.sh.in
+++ b/install.sh.in
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2148
 ENDOFSIGSTART=
 
 export PATH=/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin
@@ -216,6 +217,7 @@ _new_apt_signing() {
 	echo "deb [signed-by=/usr/share/keyrings/zerotier-debian-package-key.gpg] ${URL}debian/$CODENAME $CODENAME main" >/tmp/zt-sources-list
 }
 
+	# shellcheck disable=SC2072
 write_apt_repo() {
 	DISTRIBUTION=$1
 	VERSION=$2
@@ -230,7 +232,7 @@ write_apt_repo() {
 	$SUDO apt-get install -y gpg
 	$SUDO chmod a+r /tmp/zt-gpg-key
 
-	if   [[ "$DISTRIBUTION" == "ubuntu" && "$VERSION" < "22.04" ]]; then
+	if [[ "$DISTRIBUTION" == "ubuntu" && "$VERSION" < "22.04" ]]; then
 		_old_apt_signing $URL $CODENAME
 	elif [[ ("$DISTRIBUTION" == "debian" || "$DISTRIBUTION" == "raspbian") && "$VERSION" -lt "10" ]]; then
 		_old_apt_signing $URL $CODENAME
@@ -242,9 +244,9 @@ write_apt_repo() {
 		_new_apt_signing $URL $CODENAME
 	elif [[ "$DISTRIBUTION" == "linuxmint" && "$VERSION" == "6" ]]; then
 		_new_apt_signing $URL $CODENAME
-	elif [[ "$DISTRIBUTION" == "linuxmint" && ( "$VERSION" == "21" || "$VERSION" > "21" ) ]]; then
+	elif [[ "$DISTRIBUTION" == "linuxmint" && ( "$VERSION" == "21" || "$VERSION" -gt "21" ) ]]; then
 		_new_apt_signing $URL $CODENAME
-	elif [[ "$DISTRIBUTION" == "linuxmint" && ( "$VERSION" == "20" || ("$VERSION" > "20" && "$VERSION" < "21" ) ) ]]; then
+	elif [[ "$DISTRIBUTION" == "linuxmint" && ( "$VERSION" == "20" || ("$VERSION" -gt "20" && "$VERSION" -lt "21" ) ) ]]; then
 		_old_apt_signing $URL $CODENAME
 	else
 		echo "Unsupported distribution $DISTRIBUTION $VERSION"
@@ -296,7 +298,7 @@ elif [ $ID == "ubuntu" ] || [ $ID == "pop" ]; then
 elif [ $ID == "linuxmint" ]; then
 	echo '*** Detected Linux Mint, creating /etc/apt/sources.list.d/zerotier.list'
 
-	if [[ "$VERSION_ID" > "$MAX_SUPPORTED_MINT_VERSION" ]]; then
+	if [[ "$VERSION_ID" -gt "$MAX_SUPPORTED_MINT_VERSION" ]]; then
 		write_apt_repo $ID $MAX_SUPPORTED_MINT_VERSION $ZT_BASE_URL_HTTP $MAX_SUPPORTED_MINT_VERSION_NAME
 	else 
 		write_apt_repo $ID $VERSION_ID $ZT_BASE_URL_HTTP ${MINT_CODENAME_MAP[${VERSION_CODENAME}]}


### PR DESCRIPTION
This only lints for "errors" `-S error` 

The shebang line is injected from build-install.sh. There was probably a reason for that, so I marked it ignored. 

There are a few more errors like:

```sh
In install.sh.in line 233:
        if   [[ "$DISTRIBUTION" == "ubuntu" && "$VERSION" < "22.04" ]]; then
                                                            ^-----^ SC2072 (error): Decimals are not supported. Either use integers only, or use bc or awk to compare.

```

if we enable warnings and info, there are ~20 things to fix. But it's style stuff like 

```sh
In install.sh.in line 364:
        cat /dev/null | $SUDO zypper addrepo -t YUM -G ${ZT_BASE_URL_HTTP}redhat/el/9 zerotier
            ^-------^ SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
```
I'll `cat` if I want to. 