### PR TITLE
Add KDE Neon to authorised distro for install script

### DIFF
--- a/install.sh.in
+++ b/install.sh.in
@@ -287,7 +287,7 @@ if [ $ID == "debian" ] || [ $ID == "raspbian" ]; then
 	else 
 		write_apt_repo $ID $VERSION_ID $ZT_BASE_URL_HTTP $VERSION_CODENAME
 	fi
-elif [ $ID == "ubuntu" ] || [ $ID == "pop" ]; then
+elif [ $ID == "ubuntu" ] || [ $ID == "pop" ] || [ $ID == "neon" ]; then
 	echo '*** Detected Ubuntu Linux, creating /etc/apt/sources.list.d/zerotier.list'
 
 	if [[ "$VERSION_ID" > "$MAX_SUPPORTED_UBUNTU_VERSION" ]]; then


### PR DESCRIPTION
KDE Neon is based off Ubuntu. I just installed it by changing the script manually and I can connect as usual.

The content of `os-release` is as follows:
```
$ cat /etc/os-release
PRETTY_NAME="KDE neon 6.1"
NAME="KDE neon"
VERSION_ID="22.04"
VERSION="6.0"
VERSION_CODENAME=jammy
ID=neon
ID_LIKE="ubuntu debian"
HOME_URL="https://neon.kde.org/"
SUPPORT_URL="https://neon.kde.org/"
BUG_REPORT_URL="https://bugs.kde.org/"
PRIVACY_POLICY_URL="https://kde.org/privacypolicy/"
UBUNTU_CODENAME=jammy
LOGO=start-here-kde-neon
```