### PR TITLE
Allow CI on PR branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,11 @@ on:
     paths:
       - install.sh.in
       - .github/workflows/ci.yml
-    # branches: [ main ]
   workflow_dispatch:
+  pull_request:
+    paths:
+      - install.sh.in
+      - .github/workflows/ci.yml
   schedule:
     - cron: "0 0 * * 0"   # weekly
 jobs:


### PR DESCRIPTION
Docs and settings claim the action won't run
for external PRs until we approve