### PR TITLE
Add mapping for MINT_CODENAME_MAP 'zara'

### DIFF
--- a/install.sh.in
+++ b/install.sh.in
@@ -74,6 +74,7 @@ MINT_CODENAME_MAP["uma"]="focal"
 MINT_CODENAME_MAP["ulyssa"]="focal"
 MINT_CODENAME_MAP["ulyana"]="focal"
 MINT_CODENAME_MAP["faye"]="bookworm"
+MINT_CODENAME_MAP["zara"]="noble"
 
 ##########################################################
 #


### PR DESCRIPTION
Adds a mapping for Linux Mint 22.2 “Zara” to the script
mapping zara to noble which i have ran the script on my own Linux Mint install and it installed without issues